### PR TITLE
Add daisyui support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,7 @@ kotlin {
 
                 // fluent-js
                 implementation("com.tryformation:fluent-kotlin:_")
+                implementation(npm("daisyui", "_"))
             }
         }
 

--- a/versions.properties
+++ b/versions.properties
@@ -51,4 +51,6 @@ version.npm.@zxing/browser=0.1.5
 
 version.npm.@zxing/library=0.21.3
 
+version.npm.daisyui=5.0.35
+
 version.org.jetbrains..markdown=0.7.3

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import { readdirSync } from 'fs'
 import { resolve } from 'path'
 import tailwindcss from '@tailwindcss/vite'
+import daisyui from 'daisyui'
 
 const kotlinEntry = resolve(__dirname, '/build/kotlin-webpack/js/developmentExecutable/app.js')
 
@@ -12,7 +13,9 @@ export default defineConfig({
   },
   clearScreen: false,
   plugins: [
-    tailwindcss(),
+    tailwindcss({
+      plugins: [daisyui]
+    }),
   ],
 //  publicDir: kotlinOutputDir,
   build: {


### PR DESCRIPTION
## Summary
- configure daisyUI plugin with the vite tailwind setup
- include daisyUI npm dependency in the jsMain gradle config
- track daisyUI with refreshVersions

## Testing
- `./gradlew build --no-daemon` *(fails: Unable to tunnel through proxy)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684209042c14832eaf3b12eac4a36dc3