### PR TITLE
Improve mobile scanning UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,26 +1,20 @@
 <!DOCTYPE html>
 <html lang="en-US">
 <head>
-    <title>Fritz2 Template App</title>
+    <title>Code Hoover</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="TODO DESCRIPTION" />
-    <meta property="og:title" content="TODO TITLE" />
-    <meta property="og:description" content="Rankquest Studio allows you to benchmark search relevance metrics for your search APIs. Start optimizing your search experience today!" />
-    <meta property="og:image" content="TODO" />
-    <meta property="og:url" content="TODO" />
+    <meta name="description" content="Code Hoover allows you to suck up QR and other codes." />
+    <meta property="og:title" content="Code Hoover" />
+    <meta property="og:description" content="Code Hoover allows you to suck up QR and other codes." />
+<!--    <meta property="og:image" content="TODO" />-->
+<!--    <meta property="og:url" content="TODO" />-->
     <meta property="og:type" content="website" />
-    <!-- needs to point at src because that's where vite expects source code
-    the vite tailwind plugin picks it up from there and then does the right thing to
-    produce the proper css
-    -->
     <link href="/src/styles.css" rel="stylesheet" />
 </head>
 <body>
 <div id="target"></div>
 
-<!-- needs to point at the app.js file produced by webpack
--->
 <script src="build/kotlin-webpack/js/developmentExecutable/app.js"></script>
 </body>
 </html>

--- a/public/lang/de-DE.ftl
+++ b/public/lang/de-DE.ftl
@@ -4,3 +4,5 @@ default-welcome-text=
 default-scan=Wusch!
 default-stop=Stopp
 default-clear=Leeren
+default-copy=Kopieren
+default-dark-mode=Dunkelmodus

--- a/public/lang/de-DE.ftl
+++ b/public/lang/de-DE.ftl
@@ -2,3 +2,5 @@ default-page-title=Code Hoover
 default-welcome-text=
     Richte deine Kamera auf Codes, um sie zu scannen und zu kopieren.
 default-scan=Wusch!
+default-stop=Stopp
+default-clear=Leeren

--- a/public/lang/en-US.ftl
+++ b/public/lang/en-US.ftl
@@ -2,3 +2,5 @@ default-page-title=Code Hoover
 default-welcome-text=
     Point your camera at codes to scan and copy.
 default-scan=Wooosh!
+default-stop=Stop
+default-clear=Clear

--- a/public/lang/en-US.ftl
+++ b/public/lang/en-US.ftl
@@ -4,3 +4,5 @@ default-welcome-text=
 default-scan=Wooosh!
 default-stop=Stop
 default-clear=Clear
+default-copy=Copy
+default-dark-mode=Dark Mode

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -1,8 +1,34 @@
 import com.tryformation.localization.Translatable
 import dev.fritz2.core.storeOf
+import kotlinx.browser.window
 import localization.Locales
 import localization.TranslationStore
 import localization.translate
+
+data class ScanResult(val text: String, val format: Int)
+
+private val barcodeFormatNames = arrayOf(
+    "AZTEC",
+    "CODABAR",
+    "CODE_39",
+    "CODE_93",
+    "CODE_128",
+    "DATA_MATRIX",
+    "EAN_8",
+    "EAN_13",
+    "ITF",
+    "MAXICODE",
+    "PDF_417",
+    "QR_CODE",
+    "RSS_14",
+    "RSS_EXPANDED",
+    "UPC_A",
+    "UPC_E",
+    "UPC_EAN_EXTENSION",
+)
+
+fun barcodeFormatName(ordinal: Int): String =
+    if (ordinal in barcodeFormatNames.indices) barcodeFormatNames[ordinal] else "Unknown"
 
 suspend fun main() {
 
@@ -12,57 +38,72 @@ suspend fun main() {
             hints = null,
             timeBetweenScansMillis = 300,
         )
-        val scansStore = storeOf(listOf<String>())
+        val scansStore = storeOf(listOf<ScanResult>())
         val scanningStore = storeOf(false)
-        article("p-5") {
-            h1("text-red-700") {
+        article("p-4 max-w-screen-sm mx-auto space-y-4") {
+            h1("text-red-700 text-center") {
                 translate(DefaultLangStrings.PageTitle)
             }
-            scanningStore.data.render {scanning ->
-                if(scanning) {
-                    button("btn btn-primary btn-xs sm:btn-sm md:btn-md lg:btn-lg xl:btn-xl") {
-                        translate(DefaultLangStrings.Stop)
-                        clicks handledBy {
-                            console.log("STOP")
-                            codeReader.stopContinuousDecode()
-                            scanningStore.update(false)
+            scanningStore.data.render { scanning ->
+                div("flex gap-2 justify-center") {
+                    if (scanning) {
+                        button("btn btn-error btn-sm") {
+                            translate(DefaultLangStrings.Stop)
+                            clicks handledBy {
+                                codeReader.stopContinuousDecode()
+                                scanningStore.update(false)
+                            }
+                        }
+                    } else {
+                        button("btn btn-primary btn-sm") {
+                            translate(DefaultLangStrings.Scan)
+                            clicks handledBy {
+                                codeReader.decodeFromInputVideoDeviceContinuously(null, "video") { result, _ ->
+                                    if (result != null) {
+                                        val text = result.text
+                                        val format = result.format
+                                        val existing = scansStore.current
+                                        if (existing.none { it.text == text }) {
+                                            scansStore.update(existing + ScanResult(text, format))
+                                        }
+                                    }
+                                }
+                                scanningStore.update(true)
+                            }
                         }
                     }
-
-                } else {
-                    button("btn btn-primary btn-xs sm:btn-sm md:btn-md lg:btn-lg xl:btn-xl") {
-                        translate(DefaultLangStrings.Scan)
-
+                    button("btn btn-secondary btn-sm") {
+                        translate(DefaultLangStrings.Clear)
                         clicks handledBy {
-                            codeReader.decodeFromInputVideoDeviceContinuously(null, "video") { result, err ->
-                                if (result != null) {
-                                    console.log(result)
-                                    val text = result.text
-                                    val existing = scansStore.current
-                                    scansStore.update(
-                                        if (text !in existing) existing + text else existing,
-                                    )
-                                }
-                            }
-                            scanningStore.update(true)
-
+                            scansStore.update(emptyList())
                         }
                     }
                 }
             }
-        }
-        p {
-            translate(DefaultLangStrings.WelcomeText)
-        }
 
-        video("m-5 h-1/2", id = "video") {
+            p {
+                translate(DefaultLangStrings.WelcomeText)
+            }
 
-        }
+            scanningStore.data.render { scanning ->
+                if (scanning) {
+                    video("mx-auto w-full h-[33vh] border rounded-md", id = "video") {}
+                }
+            }
 
-        ul {
-            scansStore.data.renderEach {
-                li {
-                    +it
+            ul("space-y-2") {
+                scansStore.data.renderEach { scan ->
+                    li("card bg-base-200 p-3") {
+                        p("break-words") { +scan.text }
+                        p("text-sm opacity-70") { +barcodeFormatName(scan.format) }
+                        button("btn btn-outline btn-xs mt-2") {
+                            attrs { title = "Copy" }
+                            +"Copy"
+                            clicks handledBy {
+                                window.navigator.clipboard.writeText(scan.text)
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -101,7 +142,8 @@ enum class DefaultLangStrings : Translatable {
     PageTitle,
     WelcomeText,
     Scan,
-    Stop
+    Stop,
+    Clear
     ;
 
     // fluent files have identifiers with this prefix and the camel

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -65,7 +65,7 @@ suspend fun main() {
                                 clicks handledBy {
                                     codeReader.decodeFromInputVideoDeviceContinuously(
                                         null,
-                                        "video"
+                                        "video",
                                     ) { result, _ ->
                                         if (result != null) {
                                             val text = result.text
@@ -75,8 +75,8 @@ suspend fun main() {
                                                 scansStore.update(
                                                     existing + ScanResult(
                                                         text,
-                                                        format
-                                                    )
+                                                        format,
+                                                    ),
                                                 )
                                             }
                                         }
@@ -122,9 +122,9 @@ suspend fun main() {
             }
 
             footer("mt-auto p-4 text-center space-y-2") {
-                translationStore.data.render { currentBundle ->
-                    val currentLocale = currentBundle.bundles.first().locale.first()
-                    div("flex flex-row gap-2.5 justify-center") {
+                div("flex flex-row gap-2.5 justify-center") {
+                    translationStore.data.render { currentBundle ->
+                        val currentLocale = currentBundle.bundles.first().locale.first()
                         Locales.entries.forEach { locale ->
                             if (currentLocale == locale.title) {
                                 p {
@@ -140,16 +140,16 @@ suspend fun main() {
                             }
                         }
                     }
-                }
-                button("btn btn-ghost btn-sm hover:opacity-80 active:opacity-60 transition") {
-                    translate(DefaultLangStrings.DarkMode)
-                    clicks handledBy {
-                        val html = document.documentElement!!
-                        val current = html.getAttribute("data-theme")
-                        if (current == "dark") {
-                            html.setAttribute("data-theme", "light")
-                        } else {
-                            html.setAttribute("data-theme", "dark")
+                    button("btn btn-ghost btn-sm hover:opacity-80 active:opacity-60 transition") {
+                        translate(DefaultLangStrings.DarkMode)
+                        clicks handledBy {
+                            val html = document.documentElement!!
+                            val current = html.getAttribute("data-theme")
+                            if (current == "dark") {
+                                html.setAttribute("data-theme", "light")
+                            } else {
+                                html.setAttribute("data-theme", "dark")
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- style the interface with DaisyUI
- show/hide the video element only when scanning
- display scanned codes in nicely styled cards
- include barcode format and copy-to-clipboard button
- allow clearing stored codes
- add translations for new buttons

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420d9d056c832eb54336ed7298ade0