### PR TITLE
Enable JSON import/export

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
@@ -81,6 +83,12 @@ kotlin {
             }
         }
     }
+}
+
+tasks.withType<KotlinJsTest>().configureEach {
+    // Gradle 9 defaults to failing if no tests are discovered.
+    // Disable this behavior to allow build to succeed without tests.
+    failOnNoDiscoveredTests = false
 }
 
 


### PR DESCRIPTION
## Summary
- allow importing codes from a selected JSON file
- export saved codes by downloading a JSON file
- configure Gradle tests to not fail when no tests are present

## Testing
- `./gradlew compileKotlinJs`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a96e73e618832ebc9afdd8dfdbce1b