### PR TITLE
Show codes first and add hoover favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Code Hoover is a small web application that lets you scan QR codes and barcodes 
 - No ads, no nonsense.
 - Quickly scan multiple qr or bar codes - the camera view stays open and tries to scan everything you point it at.
 - Get a list of all the codes you scan
+- Opens straight to your stash of codes so you're never starting from an empty page
 - Copy the raw text to the clipboard or open links in a new tab
 - Localized in multiple languages!
 - Darkmode/lightmode support
+- Sports a cute hoover favicon to tidy up your tabs
 
 Is this useful? Maybe not for everyone. But I often want to know what the raw content of a QR or bar code is and that's what this is for.
 

--- a/index-dev.html
+++ b/index-dev.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Code Hoover</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="stylesheet" href="/src/styles.css" />
 </head>
 <body>

--- a/index-prod.html
+++ b/index-prod.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Code Hoover</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="stylesheet" href="/src/styles.css" />
 </head>
 <body>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="12" y="28" width="40" height="20" rx="10" ry="10" fill="#4CAF50"/>
+  <circle cx="22" cy="52" r="6" fill="#555"/>
+  <circle cx="42" cy="52" r="6" fill="#555"/>
+  <rect x="36" y="12" width="6" height="16" fill="#4CAF50"/>
+  <rect x="40" y="4" width="4" height="8" fill="#4CAF50"/>
+</svg>

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -64,7 +64,7 @@ private const val darkMode = "night"
 
 private const val lightMode = "emerald"
 
-enum class Screen { Scan, Codes }
+enum class Screen { Codes, Scan }
 
 suspend fun main() {
 
@@ -89,7 +89,7 @@ suspend fun main() {
         savedCodesStore.data.onEach { codes ->
             localStorage.setItem("codes", json.encodeToString(codes))
         }.launchIn(MainScope())
-        val screenStore = storeOf(Screen.Scan)
+        val screenStore = storeOf(Screen.Codes)
         val translationStore = withKoin { get<TranslationStore>() }
         div("min-h-screen flex flex-col") {
             article("p-4 max-w-screen-sm mx-auto space-y-4 flex-grow") {
@@ -98,16 +98,19 @@ suspend fun main() {
                 }
                 div("flex gap-2 justify-center mb-4") {
                     button("btn btn-sm") {
-                        +"Scan"
-                        clicks handledBy { screenStore.update(Screen.Scan) }
-                    }
-                    button("btn btn-sm") {
                         +"Codes"
                         clicks handledBy { screenStore.update(Screen.Codes) }
+                    }
+                    button("btn btn-sm") {
+                        +"Scan"
+                        clicks handledBy { screenStore.update(Screen.Scan) }
                     }
                 }
                 screenStore.data.render { screen ->
                     when (screen) {
+                        Screen.Codes -> {
+                            codesScreen(savedCodesStore, json)
+                        }
                         Screen.Scan -> {
                             scanningStore.data.render { scanning ->
                                 div("flex gap-2 justify-center") {
@@ -212,9 +215,6 @@ suspend fun main() {
                                     }
                                 }
                             }
-                        }
-                        Screen.Codes -> {
-                            codesScreen(savedCodesStore, json)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Show saved codes screen by default and adjust buttons accordingly
- Add hoover-themed favicon and include in HTML templates
- Document new default behavior and favicon in README

## Testing
- `./gradlew jsBrowserProductionWebpack`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a988328ef4832e934ce1b2fdfb13ff