### PR TITLE
Fix drag-and-drop misplacement with duplicate codes

### DIFF
--- a/src/jsMain/kotlin/qr/CodesScreen.kt
+++ b/src/jsMain/kotlin/qr/CodesScreen.kt
@@ -171,8 +171,9 @@ fun RenderContext.codesScreen(
                 }
             }
             ul("space-y-4") {
-                savedCodesStore.data.renderEach { code ->
-                    val index = savedCodesStore.current.indexOf(code)
+                savedCodesStore.data.map { it.withIndex().toList() }.renderEach { indexed ->
+                    val index = indexed.index
+                    val code = indexed.value
                     val displayName = code.name.ifBlank { code.text }
                     val truncated = if (displayName.length > 60) displayName.take(60) + "..." else displayName
                     li("card bg-base-200 p-4 flex justify-between items-center cursor-pointer") {


### PR DESCRIPTION
## Summary
- use indexed rendering for saved code list so drag-and-drop uses correct item indices

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68a9929343cc832eb031e7d1736381fd