### PR TITLE
refactor: extract UI components and simplify styling

### DIFF
--- a/src/jsMain/kotlin/CodesScreen.kt
+++ b/src/jsMain/kotlin/CodesScreen.kt
@@ -1,5 +1,3 @@
-package qr
-
 import dev.fritz2.core.*
 import kotlinx.browser.document
 import kotlinx.browser.window
@@ -9,12 +7,17 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import org.w3c.dom.DragEvent
 import org.w3c.dom.HTMLAnchorElement
 import org.w3c.dom.HTMLInputElement
-import org.w3c.dom.DragEvent
 import org.w3c.dom.HTMLElement
 import org.w3c.files.FileReader
-import QrForm
+import qr.QrData
+import qr.QrType
+import qr.SavedQrCode
+import qr.asText
+import qr.format
+import qr.generateQrSvg
 import DefaultLangStrings
 import localization.getTranslationString
 import localization.translate
@@ -130,8 +133,8 @@ fun RenderContext.codesScreen(
                 }
             }
         } else {
-            div("flex gap-4 mb-6") {
-                button("btn btn-primary btn-sm") {
+            div("join flex-wrap mb-6") {
+                button("btn btn-primary btn-sm w-24") {
                     translate(DefaultLangStrings.Add)
                     clicks handledBy {
                         formStore.update(QrForm())
@@ -164,13 +167,13 @@ fun RenderContext.codesScreen(
                     })
                 }
 
-                button("btn btn-secondary btn-sm") {
+                button("btn btn-secondary btn-sm w-24") {
                     translate(DefaultLangStrings.Import)
                     clicks handledBy {
                         fileInput.domNode.click()
                     }
                 }
-                button("btn btn-secondary btn-sm") {
+                button("btn btn-secondary btn-sm w-24") {
                     translate(DefaultLangStrings.Export)
                     clicks handledBy {
                         val txt = json.encodeToString(savedCodesStore.current)
@@ -184,7 +187,7 @@ fun RenderContext.codesScreen(
                     }
                 }
             }
-            ul("flex flex-col gap-4") {
+            ul("flex flex-col gap-4 w-full") {
                 val listElement = domNode
 
                 listElement.addEventListener("dragover", { event ->
@@ -238,10 +241,10 @@ fun RenderContext.codesScreen(
                     val code = indexed.value
                     val displayName = code.name.ifBlank { code.text }
                     val truncated = if (displayName.length > 60) displayName.take(60) + "..." else displayName
-                    li("card bg-base-200 p-4 flex justify-between items-center cursor-pointer") {
+                    li("card bg-base-200 p-4 flex justify-between items-center cursor-pointer w-full") {
                         attr("draggable", "true")
                         p("mr-2 flex-grow truncate") { +truncated }
-                        button("btn btn-xs btn-warning") {
+                        button("btn btn-xs btn-warning w-24") {
                             translate(DefaultLangStrings.Delete)
                             clicks.map { it.stopPropagation(); Unit } handledBy {
                                 val list = savedCodesStore.current.toMutableList()

--- a/src/jsMain/kotlin/QrForm.kt
+++ b/src/jsMain/kotlin/QrForm.kt
@@ -1,0 +1,15 @@
+import qr.QrType
+
+data class QrForm(
+    val name: String = "",
+    val type: QrType = QrType.URL,
+    val url: String = "",
+    val text: String = "",
+    val fullName: String = "",
+    val phone: String = "",
+    val email: String = "",
+    val ssid: String = "",
+    val password: String = "",
+    val encryption: String = "WPA",
+    val index: Int? = null,
+)

--- a/src/jsMain/kotlin/ScanResult.kt
+++ b/src/jsMain/kotlin/ScanResult.kt
@@ -1,0 +1,1 @@
+data class ScanResult(val text: String, val format: Int)

--- a/src/jsMain/kotlin/ScanScreen.kt
+++ b/src/jsMain/kotlin/ScanScreen.kt
@@ -1,0 +1,117 @@
+import dev.fritz2.core.*
+import kotlinx.browser.window
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import qr.QrData
+import qr.SavedQrCode
+import qr.asText
+import localization.getTranslationString
+import localization.translate
+import DefaultLangStrings
+
+fun RenderContext.scanScreen(
+    scanningStore: Store<Boolean>,
+    scansStore: Store<List<ScanResult>>,
+    codeReader: BrowserMultiFormatReader,
+    savedCodesStore: Store<List<SavedQrCode>>,
+    json: Json
+) {
+    scanningStore.data.render { scanning ->
+        section("flex flex-col items-center gap-4 w-full") {
+            div("join flex-wrap justify-center") {
+                if (scanning) {
+                    button("btn btn-error btn-sm w-24") {
+                        translate(DefaultLangStrings.Stop)
+                        clicks handledBy {
+                            codeReader.stopContinuousDecode()
+                            scanningStore.update(false)
+                        }
+                    }
+                } else {
+                    button("btn btn-primary btn-sm w-24") {
+                        translate(DefaultLangStrings.Scan)
+                        clicks handledBy {
+                            codeReader.decodeFromInputVideoDeviceContinuously(
+                                null,
+                                "video",
+                            ) { result, _ ->
+                                if (result != null) {
+                                    val text = result.text
+                                    val format = result.format
+                                    val existing = scansStore.current
+                                    if (existing.none { it.text == text }) {
+                                        scansStore.update(
+                                            listOf(ScanResult(text, format)) + existing,
+                                        )
+                                    }
+                                }
+                            }
+                            scanningStore.update(true)
+                        }
+                    }
+                }
+                button("btn btn-secondary btn-sm w-24") {
+                    translate(DefaultLangStrings.Clear)
+                    clicks handledBy {
+                        scansStore.update(emptyList())
+                    }
+                }
+            }
+            if (!scanning) {
+                p { translate(DefaultLangStrings.WelcomeText) }
+            } else {
+                video("mx-auto w-full h-[33vh] border rounded-md", id = "video") {}
+            }
+        }
+    }
+    scansStore.data.render { scans ->
+        p("font-semibold mb-2") {
+            translate(DefaultLangStrings.ScannedCodes, mapOf("count" to scans.size))
+        }
+    }
+    ul("space-y-2 w-full") {
+        scansStore.data.renderEach { scan ->
+            li("card bg-base-200 p-3 w-full") {
+                p("break-words font-mono") { +scan.text }
+                p("text-xs opacity-70") { +barcodeFormatName(scan.format) }
+                div("mt-2 join flex-wrap") {
+                    button("btn btn-primary btn-xs w-24") {
+                        attr("title", getTranslationString(DefaultLangStrings.Copy))
+                        translate(DefaultLangStrings.Copy)
+                        clicks handledBy { window.navigator.clipboard.writeText(scan.text) }
+                    }
+                    if (scan.text.startsWith("http://") || scan.text.startsWith("https://")) {
+                        button("btn btn-secondary btn-xs w-24") {
+                            translate(DefaultLangStrings.Open)
+                            clicks handledBy { window.open(scan.text, "_blank") }
+                        }
+                    }
+                    button("btn btn-accent btn-xs w-24") {
+                        translate(DefaultLangStrings.Save)
+                        clicks handledBy {
+                            val entry = if (barcodeFormatName(scan.format) == "QR_CODE") {
+                                try {
+                                    json.decodeFromString<SavedQrCode>(scan.text)
+                                        .let { if (it.name.isBlank()) it.copy(name = it.text) else it }
+                                } catch (_: Throwable) {
+                                    val data = QrData.Text(scan.text)
+                                    SavedQrCode(scan.text, data.asText(), data)
+                                }
+                            } else {
+                                val data = QrData.Text(scan.text)
+                                SavedQrCode(scan.text, data.asText(), data)
+                            }
+                            savedCodesStore.update(savedCodesStore.current + entry)
+                        }
+                    }
+                    button("btn btn-warning btn-xs w-24") {
+                        translate(DefaultLangStrings.Delete)
+                        clicks handledBy {
+                            scansStore.update(scansStore.current.filterNot { it == scan })
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor to move UI screens to root and extract `ScanScreen`
- standardize button widths and replace ad-hoc classes with DaisyUI helpers
- keep layout responsive with simpler structure

## Testing
- `./gradlew build`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9c5073360832ea922cd2549cd20e7