### PR TITLE
feat: migrate to zxing browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Hoover
 
-Code Hoover is a small web application that lets you scan QR codes and barcodes directly in the browser. It is written in Kotlin/JS using the fritz2 framework and relies on the excellent [ZXing JavaScript library](https://github.com/zxing-js/library) for the heavy lifting when decoding codes.
+Code Hoover is a small web application that lets you scan QR codes and barcodes directly in the browser. It is written in Kotlin/JS using the fritz2 framework and relies on the excellent [@zxing/browser](https://github.com/zxing-js/browser) package for the heavy lifting when decoding codes.
 
 [![Screenshot](screenshot.webp)](URL)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation("io.kotest:kotest-assertions-core:_")
+                implementation(npm("@zxing/browser","_"))
                 implementation(npm("@zxing/library","_"))
             }
         }
@@ -65,6 +66,7 @@ kotlin {
 
                 // fluent-js
                 implementation("com.tryformation:fluent-kotlin:_")
+                implementation(npm("@zxing/browser","_"))
                 implementation(npm("@zxing/library","_"))
                 implementation(npm("qrcode","_"))
             }

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -434,6 +434,13 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@zxing/browser@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@zxing/browser/-/browser-0.1.5.tgz#94c0cdbc8ab5114a82dadee54939de6d9bf7e313"
+  integrity sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==
+  optionalDependencies:
+    "@zxing/text-encoding" "^0.9.0"
+
 "@zxing/library@0.21.3":
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/@zxing/library/-/library-0.21.3.tgz#0a4cb777701884131832b05922d7e88ef1b87ab4"
@@ -443,7 +450,7 @@
   optionalDependencies:
     "@zxing/text-encoding" "~0.9.0"
 
-"@zxing/text-encoding@~0.9.0":
+"@zxing/text-encoding@^0.9.0", "@zxing/text-encoding@~0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
   integrity sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -58,7 +58,7 @@ suspend fun main() {
 
         val codeReader = BrowserMultiFormatReader(
             hints = null,
-            timeBetweenScansMillis = 300,
+            options = js("{ delayBetweenScanAttempts: 300 }")
         )
         val scansStore = storeOf(listOf<ScanResult>())
         val scanningStore = storeOf(false)

--- a/src/jsMain/kotlin/ScanScreen.kt
+++ b/src/jsMain/kotlin/ScanScreen.kt
@@ -16,6 +16,7 @@ fun RenderContext.scanScreen(
     savedCodesStore: Store<List<SavedQrCode>>,
     json: Json
 ) {
+    var controls: IScannerControls? = null
     scanningStore.data.render { scanning ->
         section("flex flex-col items-center gap-4 w-full") {
             div("join flex-wrap justify-center") {
@@ -24,7 +25,8 @@ fun RenderContext.scanScreen(
                         iconStop()
                         translate(DefaultLangStrings.Stop)
                         clicks handledBy {
-                            codeReader.stopContinuousDecode()
+                            controls?.stop()
+                            controls = null
                             scanningStore.update(false)
                         }
                     }
@@ -33,10 +35,11 @@ fun RenderContext.scanScreen(
                         iconCamera()
                         translate(DefaultLangStrings.Scan)
                         clicks handledBy {
-                            codeReader.decodeFromInputVideoDeviceContinuously(
+                            codeReader.decodeFromVideoDevice(
                                 null,
                                 "video",
-                            ) { result, _ ->
+                            ) { result, _, c ->
+                                controls = c
                                 if (result != null) {
                                     val text = result.text
                                     val format = result.format

--- a/src/jsMain/kotlin/zxing.kt
+++ b/src/jsMain/kotlin/zxing.kt
@@ -1,4 +1,4 @@
-@file:JsModule("@zxing/library")
+@file:JsModule("@zxing/browser")
 @file:JsNonModule
 
 import kotlin.js.Promise
@@ -8,24 +8,25 @@ external interface ZXingResult {
     val text: String
 }
 
+external interface IScannerControls {
+    fun stop()
+}
+
 external class BrowserMultiFormatReader(
-    hints: dynamic,
-    timeBetweenScansMillis: Int
+    hints: dynamic = definedExternally,
+    options: dynamic = definedExternally,
 ) {
     fun decodeOnceFromVideoDevice(
         deviceId: String?,
         videoElementId: String?,
     ): Promise<ZXingResult>
 
-    fun decodeFromInputVideoDeviceContinuously(
+    fun decodeFromVideoDevice(
         deviceId: String?,
         videoSource: String?,
-        callbackFn: (ZXingResult?, Throwable?) -> Unit
-    ): Promise<Unit>
-
-    fun stopContinuousDecode()
-
-    fun stopAsyncDecode()
+        callbackFn: (ZXingResult?, Throwable?, IScannerControls) -> Unit,
+    ): Promise<IScannerControls>
 
     fun reset()
 }
+

--- a/versions.properties
+++ b/versions.properties
@@ -31,6 +31,7 @@ version.kotlinx.datetime=0.7.1
 version.kotlinx.serialization=1.9.0
 
 ## unused
+version.npm.@zxing/browser=0.1.5
 version.npm.@zxing/library=0.21.3
 
 version.npm.qrcode=1.5.4


### PR DESCRIPTION
## Summary
- replace deprecated @zxing/library with @zxing/browser
- update Kotlin bindings and scanning code for new API
- refresh dependency versions and yarn lock

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68bf3ad8f410832e9c287a77968c1d22