### PR TITLE
Update header layout with logo

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect x="12" y="28" width="40" height="20" rx="10" ry="10" fill="#4CAF50"/>
-  <circle cx="22" cy="52" r="6" fill="#555"/>
-  <circle cx="42" cy="52" r="6" fill="#555"/>
-  <rect x="36" y="12" width="6" height="16" fill="#4CAF50"/>
-  <rect x="40" y="4" width="4" height="8" fill="#4CAF50"/>
+  <rect x="12" y="28" width="40" height="20" rx="10" ry="10" fill="#000000"/>
+  <circle cx="22" cy="52" r="6" fill="#000000"/>
+  <circle cx="42" cy="52" r="6" fill="#000000"/>
+  <rect x="36" y="12" width="6" height="16" fill="#000000"/>
+  <rect x="40" y="4" width="4" height="8" fill="#000000"/>
 </svg>

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -79,7 +79,16 @@ suspend fun main() {
         val translationStore = withKoin { get<TranslationStore>() }
         div("min-h-screen flex flex-col bg-base-100 text-base-content") {
             article("p-6 max-w-screen-sm mx-auto flex flex-col gap-6 flex-grow") {
-                div("flex justify-end") {
+                div("flex flex-wrap items-center justify-between gap-4") {
+                    div("flex items-center gap-3") {
+                        img("h-10 w-10 dark:invert") {
+                            attr("src", "/favicon.svg")
+                            attr("alt", "Code Hoover logo")
+                        }
+                        h1("text-2xl sm:text-3xl font-bold text-primary") {
+                            translate(DefaultLangStrings.PageTitle)
+                        }
+                    }
                     div("dropdown dropdown-end") {
                         label("btn btn-ghost btn-circle") {
                             tabIndex(0)
@@ -138,7 +147,7 @@ suspend fun main() {
                                         svg("swap-off h-10 w-10 fill-current") {
                                             attr("xmlns", "http://www.w3.org/2000/svg")
                                             attr("viewBox", "0 0 24 24")
-                        
+
                                             path {
                                                 attr(
                                                     "d",
@@ -161,9 +170,6 @@ suspend fun main() {
                             }
                         }
                     }
-                }
-                h1("text-center text-2xl sm:text-3xl font-bold text-primary") {
-                    translate(DefaultLangStrings.PageTitle)
                 }
                 screenStore.data.render { screen ->
                     div("tabs tabs-boxed justify-center mb-6") {


### PR DESCRIPTION
## Summary
- align the header controls, logo, and page title in a single row while keeping the menu accessible
- display the favicon as a header logo with dark-mode inversion styling
- recolor the favicon artwork to solid black so it inverts cleanly for dark mode

## Testing
- npm run build *(fails: Vite cannot find the production executable bundle without running the Kotlin build first)*
- ./gradlew jsBrowserDevelopmentWebpack --console=plain *(fails: kotlinStoreYarnLock requires running kotlinUpgradeYarnLock)*

------
https://chatgpt.com/codex/tasks/task_e_68ca83a41634832e86a7ec11a3918fcd