### PR TITLE
Extract reusable QR code image component

### DIFF
--- a/src/jsMain/kotlin/AboutScreen.kt
+++ b/src/jsMain/kotlin/AboutScreen.kt
@@ -1,9 +1,5 @@
 import dev.fritz2.core.*
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
-import kotlinx.browser.window
 import localization.translate
-import qr.generateQrSvg
 import DefaultLangStrings
 
 fun RenderContext.aboutScreen() {
@@ -14,12 +10,7 @@ fun RenderContext.aboutScreen() {
         h2("text-xl font-bold") { translate(DefaultLangStrings.About) }
         p { translate(DefaultLangStrings.AboutIntro) }
         div("flex flex-col items-center gap-2") {
-            val repoImg = img("w-32 h-32") {}
-            MainScope().launch {
-                val svg = generateQrSvg(repoUrl, 200)
-                val encoded = window.btoa(svg)
-                repoImg.domNode.setAttribute("src", "data:image/svg+xml;base64,$encoded")
-            }
+            qrCodeImage(repoUrl, size = 200, classes = "w-32 h-32") {}
             a("link link-primary") {
                 href(repoUrl)
                 attr("target", "_blank")
@@ -27,12 +18,7 @@ fun RenderContext.aboutScreen() {
             }
         }
         div("flex flex-col items-center gap-2") {
-            val videoImg = img("w-32 h-32") {}
-            MainScope().launch {
-                val svg = generateQrSvg(videoUrl, 200)
-                val encoded = window.btoa(svg)
-                videoImg.domNode.setAttribute("src", "data:image/svg+xml;base64,$encoded")
-            }
+            qrCodeImage(videoUrl, size = 200, classes = "w-32 h-32") {}
             a("link link-primary") {
                 href(videoUrl)
                 attr("target", "_blank")

--- a/src/jsMain/kotlin/CodesScreen.kt
+++ b/src/jsMain/kotlin/CodesScreen.kt
@@ -1,9 +1,7 @@
 import dev.fritz2.core.*
 import kotlinx.browser.document
 import kotlinx.browser.window
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -16,7 +14,6 @@ import qr.QrType
 import qr.SavedQrCode
 import qr.asText
 import qr.format
-import qr.generateQrSvg
 import DefaultLangStrings
 import localization.getTranslationString
 import localization.translate
@@ -115,14 +112,13 @@ fun RenderContext.codesScreen(
                         li(
                             "card bg-base-200 p-4 cursor-pointer w-full flex flex-col items-center gap-3 text-center"
                         ) {
-                            val preview = img("h-24 w-24 mx-auto pointer-events-none") {
+                            qrCodeImage(
+                                text = code.text,
+                                size = 160,
+                                classes = "h-24 w-24 mx-auto pointer-events-none",
+                            ) {
                                 attr("alt", displayName)
                                 attr("loading", "lazy")
-                            }
-                            MainScope().launch {
-                                val svg = generateQrSvg(code.text, 160)
-                                val encoded = window.btoa(svg)
-                                preview.domNode.setAttribute("src", "data:image/svg+xml;base64,$encoded")
                             }
                             p("w-full truncate font-medium") { +truncated }
                             clicks handledBy { selectedIndexStore.update(index) }
@@ -172,15 +168,12 @@ fun RenderContext.codesScreen(
                                 iconXMark()
                                 clicks handledBy { close(false) }
                             }
-                            val imgElem = img("mx-auto") {
+                            qrCodeImage(
+                                text = modalFormStore.data.map { it.toQrData().asText() },
+                                size = 500,
+                                classes = "mx-auto",
+                            ) {
                                 attr("alt", initial.name.ifBlank { initial.text })
-                            }
-                            modalFormStore.data.map { it.toQrData().asText() }.handledBy { txt ->
-                                MainScope().launch {
-                                    val svg = generateQrSvg(txt, 500)
-                                    val encoded = window.btoa(svg)
-                                    imgElem.domNode.setAttribute("src", "data:image/svg+xml;base64,$encoded")
-                                }
                             }
                             pre("whitespace-pre-wrap break-words max-w-sm mx-auto text-left") {
                                 modalFormStore.data.map { it.toQrData().format() }.renderText()

--- a/src/jsMain/kotlin/QrCodeComponent.kt
+++ b/src/jsMain/kotlin/QrCodeComponent.kt
@@ -1,0 +1,35 @@
+import dev.fritz2.core.RenderContext
+import dev.fritz2.core.Tag
+import dev.fritz2.core.handledBy
+import dev.fritz2.core.img
+import kotlinx.browser.window
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.mapLatest
+import org.w3c.dom.HTMLImageElement
+import qr.generateQrSvg
+
+fun RenderContext.qrCodeImage(
+    text: Flow<String>,
+    size: Int = 200,
+    classes: String = "",
+    builder: Tag<HTMLImageElement>.() -> Unit = {},
+): Tag<HTMLImageElement> {
+    val image = img(classes) {
+        builder()
+    }
+    text.mapLatest { value ->
+        val svg = generateQrSvg(value, size)
+        window.btoa(svg)
+    } handledBy { encoded ->
+        image.domNode.setAttribute("src", "data:image/svg+xml;base64,$encoded")
+    }
+    return image
+}
+
+fun RenderContext.qrCodeImage(
+    text: String,
+    size: Int = 200,
+    classes: String = "",
+    builder: Tag<HTMLImageElement>.() -> Unit = {},
+): Tag<HTMLImageElement> = qrCodeImage(flowOf(text), size, classes, builder)


### PR DESCRIPTION
## Summary
- add a reusable `qrCodeImage` renderer that encapsulates the SVG generation and base64 encoding
- replace the duplicated QR image setup in the About and Codes screens with the new helper

## Testing
- `npm run build` *(fails: requires Kotlin webpack bundle prior to running Vite)*
- `./gradlew -Pkotlin.js.yarn.ignore.yarn.lock=true jsBrowserDevelopmentWebpack` *(hangs on `> IDLE`, cancelled)*
- `./gradlew -Pkotlin.js.yarn.ignore.yarn.lock=true jsBrowserDistribution` *(hangs on `> IDLE`, cancelled)*
- `./gradlew -Pkotlin.js.yarn.ignore.yarn.lock=true jsBrowserProductionWebpack` *(hangs on `> IDLE`, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9da38c98832eb352a2e5f594fb11