### PR TITLE
Adjust menu and card styling

### DIFF
--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -96,7 +96,7 @@ suspend fun main() {
                             tabIndex(0)
                             iconBars()
                         }
-                        ul("menu menu-sm dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-52") {
+                        ul("menu menu-sm dropdown-content mt-3 p-2 shadow bg-base-200 rounded-2xl w-52") {
                             tabIndex(0)
                             li {
                                 button("w-full text-left") {
@@ -119,14 +119,17 @@ suspend fun main() {
                                                 Locales.FR_FR -> "🇫🇷"
                                                 Locales.JA_JP -> "🇯🇵"
                                             }
-                                            button(
-                                                "btn btn-ghost btn-sm w-8 text-2xl filter grayscale hover:grayscale-0 " +
-                                                    if (currentLocale == locale.title) "grayscale-0" else "",
-                                            ) {
-                                                +flag
-                                                attr("aria-label", locale.title)
-                                                clicks handledBy {
-                                                    translationStore.updateLocale(locale.title)
+                                            div("tooltip tooltip-bottom") {
+                                                attr("data-tip", locale.title)
+                                                button(
+                                                    "btn btn-ghost btn-sm w-8 text-2xl filter grayscale hover:grayscale-0 " +
+                                                        if (currentLocale == locale.title) "grayscale-0" else "",
+                                                ) {
+                                                    +flag
+                                                    attr("aria-label", locale.title)
+                                                    clicks handledBy {
+                                                        translationStore.updateLocale(locale.title)
+                                                    }
                                                 }
                                             }
                                         }

--- a/src/jsMain/kotlin/CodesScreen.kt
+++ b/src/jsMain/kotlin/CodesScreen.kt
@@ -113,7 +113,7 @@ fun RenderContext.codesScreen(
                         val displayName = code.name.ifBlank { code.text }
                         val truncated = if (displayName.length > 60) displayName.take(60) + "..." else displayName
                         li(
-                            "card bg-base-200 p-4 cursor-pointer w-full flex flex-col items-center gap-3 text-center"
+                            "card bg-base-200 rounded-2xl p-4 cursor-pointer w-full flex flex-col items-center gap-3 text-center"
                         ) {
                             val preview = img("h-24 w-24 mx-auto pointer-events-none") {
                                 attr("alt", displayName)


### PR DESCRIPTION
## Summary
- round the saved code cards for a softer layout
- apply the card background and rounded corners to the hamburger dropdown
- show locale code tooltips when hovering the language flag buttons

## Testing
- npm run build *(fails: Failed to resolve /build/kotlin-webpack/js/productionExecutable/app.js)*
- ./gradlew -Pkotlin.js.yarn.ignore.yarn.lock=true jsBrowserDevelopmentWebpack --console=plain *(fails: NoSuchFileException for /workspace/code-hoover/build/classes/kotlin/js/main/default/linkdata/module)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9e3c27cc832e8e958384efbd5dd6