### PR TITLE
Update about screen layout and add migration QR

### DIFF
--- a/public/lang/de-DE.ftl
+++ b/public/lang/de-DE.ftl
@@ -40,3 +40,5 @@ default-about-intro=Code Hoover lets you scan and generate QR codes directly in 
 default-github-repo=GitHub repository
 default-veritasium-video=Veritasium video on QR codes
 default-open-source-statement=This project is free and open source.
+default-open-on-different-device=Open on a different device
+default-migration-instructions=Migration instructions: Simply open Code Hoover on another device with this QR code and then go to the scan page to hoover up any codes you have on this device and save them.

--- a/public/lang/en-US.ftl
+++ b/public/lang/en-US.ftl
@@ -40,3 +40,5 @@ default-about-intro=Code Hoover lets you scan and generate QR codes directly in 
 default-github-repo=GitHub repository
 default-veritasium-video=Veritasium video on QR codes
 default-open-source-statement=This project is free and open source.
+default-open-on-different-device=Open on a different device
+default-migration-instructions=Migration instructions: Simply open Code Hoover on another device with this QR code and then go to the scan page to hoover up any codes you have on this device and save them.

--- a/public/lang/fr-FR.ftl
+++ b/public/lang/fr-FR.ftl
@@ -40,4 +40,6 @@ default-about-intro=Code Hoover lets you scan and generate QR codes directly in 
 default-github-repo=GitHub repository
 default-veritasium-video=Veritasium video on QR codes
 default-open-source-statement=This project is free and open source.
+default-open-on-different-device=Open on a different device
+default-migration-instructions=Migration instructions: Simply open Code Hoover on another device with this QR code and then go to the scan page to hoover up any codes you have on this device and save them.
 

--- a/public/lang/ja-JP.ftl
+++ b/public/lang/ja-JP.ftl
@@ -40,4 +40,6 @@ default-about-intro=Code Hoover lets you scan and generate QR codes directly in 
 default-github-repo=GitHub repository
 default-veritasium-video=Veritasium video on QR codes
 default-open-source-statement=This project is free and open source.
+default-open-on-different-device=Open on a different device
+default-migration-instructions=Migration instructions: Simply open Code Hoover on another device with this QR code and then go to the scan page to hoover up any codes you have on this device and save them.
 

--- a/public/lang/nl-NL.ftl
+++ b/public/lang/nl-NL.ftl
@@ -40,4 +40,6 @@ default-about-intro=Code Hoover lets you scan and generate QR codes directly in 
 default-github-repo=GitHub repository
 default-veritasium-video=Veritasium video on QR codes
 default-open-source-statement=This project is free and open source.
+default-open-on-different-device=Open on a different device
+default-migration-instructions=Migration instructions: Simply open Code Hoover on another device with this QR code and then go to the scan page to hoover up any codes you have on this device and save them.
 

--- a/src/jsMain/kotlin/AboutScreen.kt
+++ b/src/jsMain/kotlin/AboutScreen.kt
@@ -5,11 +5,12 @@ import DefaultLangStrings
 fun RenderContext.aboutScreen() {
     val repoUrl = "https://github.com/felko/code-hoover"
     val videoUrl = "https://www.youtube.com/watch?v=w5ebcowAJD8"
+    val differentDeviceUrl = "https://codehoover.jillesvangurp.com"
 
-    div("flex flex-col items-center gap-4 text-center") {
+    div("flex flex-col gap-4 text-left items-start") {
         h2("text-xl font-bold") { translate(DefaultLangStrings.About) }
         p { translate(DefaultLangStrings.AboutIntro) }
-        div("flex flex-col items-center gap-2") {
+        div("flex flex-col items-center gap-2 self-center") {
             qrCodeImage(repoUrl, size = 200, classes = "w-32 h-32") {}
             a("link link-primary") {
                 href(repoUrl)
@@ -17,7 +18,7 @@ fun RenderContext.aboutScreen() {
                 translate(DefaultLangStrings.GithubRepo)
             }
         }
-        div("flex flex-col items-center gap-2") {
+        div("flex flex-col items-center gap-2 self-center") {
             qrCodeImage(videoUrl, size = 200, classes = "w-32 h-32") {}
             a("link link-primary") {
                 href(videoUrl)
@@ -25,6 +26,15 @@ fun RenderContext.aboutScreen() {
                 translate(DefaultLangStrings.VeritasiumVideo)
             }
         }
+        div("flex flex-col items-center gap-2 self-center") {
+            qrCodeImage(differentDeviceUrl, size = 200, classes = "w-32 h-32") {}
+            a("link link-primary") {
+                href(differentDeviceUrl)
+                attr("target", "_blank")
+                translate(DefaultLangStrings.OpenOnDifferentDevice)
+            }
+        }
         p { translate(DefaultLangStrings.OpenSourceStatement) }
+        p { translate(DefaultLangStrings.MigrationInstructions) }
     }
 }

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -260,6 +260,8 @@ enum class DefaultLangStrings : Translatable {
     GithubRepo,
     VeritasiumVideo,
     OpenSourceStatement,
+    OpenOnDifferentDevice,
+    MigrationInstructions,
     ;
 
     // fluent files have identifiers with this prefix and the camel


### PR DESCRIPTION
## Summary
- left-align the About screen text while keeping QR sections centered
- add an “Open on a different device” QR code with migration instructions
- extend the default language strings to cover the new QR code and messaging

## Testing
- `./gradlew -Pkotlin.js.yarn.ignore.yarn.lock=true jsBrowserDevelopmentWebpack --console=plain` *(fails: `:kotlinStoreYarnLock` requires running kotlinUpgradeYarnLock due to lock file change)*

------
https://chatgpt.com/codex/tasks/task_e_68cbee482f90832ebb63d24e6c153d92