### PR TITLE
Add progressive web app support

### DIFF
--- a/index-dev.html
+++ b/index-dev.html
@@ -3,8 +3,10 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#111827" />
     <title>Code Hoover</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="stylesheet" href="/src/styles.css" />
 </head>
 <body>

--- a/index-prod.html
+++ b/index-prod.html
@@ -3,8 +3,10 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#111827" />
     <title>Code Hoover</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="stylesheet" href="/src/styles.css" />
 </head>
 <body>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "Code Hoover",
+  "short_name": "CodeHoover",
+  "description": "Scan, save, and manage QR and barcodes directly in your browser.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#111827",
+  "theme_color": "#111827",
+  "lang": "en",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,75 @@
+const CACHE_NAME = 'code-hoover-cache-v1';
+const CORE_ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.webmanifest',
+  '/favicon.svg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(CORE_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  const url = new URL(request.url);
+
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  if (request.headers.get('accept')?.includes('text/event-stream')) {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+
+      return fetch(request)
+        .then((response) => {
+          if (!response || response.status !== 200 || response.type !== 'basic') {
+            return response;
+          }
+
+          const responseToCache = response.clone();
+
+          caches.open(CACHE_NAME).then((cache) => {
+            cache.put(request, responseToCache);
+          });
+
+          return response;
+        })
+        .catch(() => {
+          if (request.mode === 'navigate') {
+            return caches.match('/index.html');
+          }
+
+          return caches.match(request);
+        });
+    })
+  );
+});

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -20,6 +20,7 @@ import org.w3c.dom.HTMLAnchorElement
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.HTMLElement
 import org.w3c.files.FileReader
+import org.w3c.dom.events.Event
 
 
 private val barcodeFormatNames = arrayOf(
@@ -54,6 +55,12 @@ private const val lightMode = "qr-light"
 enum class Screen { Codes, Scan, About }
 
 suspend fun main() {
+
+    if (js("import.meta.env.PROD") as Boolean) {
+        window.addEventListener("load", { _: Event ->
+            window.navigator.serviceWorker?.register("/service-worker.js")
+        })
+    }
 
     // starts up koin and initializes the TranslationStore
     startAppWithKoin {


### PR DESCRIPTION
## Summary
- add a web app manifest and service worker so Code Hoover can install and work offline
- register the service worker in the Kotlin entry point and expose the manifest in dev and prod HTML

## Testing
- `./gradlew -Pkotlin.js.yarn.ignore.yarn.lock=true jsBrowserDevelopmentWebpack --console=plain`
- `./gradlew -Pkotlin.js.yarn.ignore.yarn.lock=true jsBrowserProductionWebpack --console=plain`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa2794045c832e8f42afe27b9d76c1