### PR TITLE
Improve mobile drag-and-drop handling

### DIFF
--- a/public/lang/de-DE.ftl
+++ b/public/lang/de-DE.ftl
@@ -15,6 +15,7 @@ default-import=Importieren
 default-export=Exportieren
 default-cancel=Abbrechen
 default-close=Schließen
+default-drag-to-reorder=Zum Neuordnen ziehen
 default-scanned-codes={ $count } gescannte Codes
 default-invalid-json=Ungültiges JSON
 default-name=Name

--- a/public/lang/en-US.ftl
+++ b/public/lang/en-US.ftl
@@ -15,6 +15,7 @@ default-import=Import
 default-export=Export
 default-cancel=Cancel
 default-close=Close
+default-drag-to-reorder=Drag to reorder
 default-scanned-codes={ $count } scanned codes
 default-invalid-json=Invalid JSON
 default-name=Name

--- a/public/lang/fr-FR.ftl
+++ b/public/lang/fr-FR.ftl
@@ -15,6 +15,7 @@ default-import=Importer
 default-export=Exporter
 default-cancel=Annuler
 default-close=Fermer
+default-drag-to-reorder=Faites glisser pour réorganiser
 default-scanned-codes={ $count } codes scannés
 default-invalid-json=JSON invalide
 default-name=Nom

--- a/public/lang/ja-JP.ftl
+++ b/public/lang/ja-JP.ftl
@@ -15,6 +15,7 @@ default-import=インポート
 default-export=エクスポート
 default-cancel=キャンセル
 default-close=閉じる
+default-drag-to-reorder=ドラッグして並べ替え
 default-scanned-codes={ $count } 件のコードをスキャンしました
 default-invalid-json=無効なJSON
 default-name=名前

--- a/public/lang/nl-NL.ftl
+++ b/public/lang/nl-NL.ftl
@@ -15,6 +15,7 @@ default-import=Importeren
 default-export=Exporteren
 default-cancel=Annuleren
 default-close=Sluiten
+default-drag-to-reorder=Sleep om opnieuw te ordenen
 default-scanned-codes={ $count } gescande codes
 default-invalid-json=Ongeldige JSON
 default-name=Naam

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -291,6 +291,7 @@ enum class DefaultLangStrings : Translatable {
     Export,
     Cancel,
     Close,
+    DragToReorder,
     ScannedCodes,
     InvalidJson,
     Name,

--- a/src/jsMain/kotlin/CodesScreen.kt
+++ b/src/jsMain/kotlin/CodesScreen.kt
@@ -16,6 +16,7 @@ import localization.translate
 import org.w3c.dom.HTMLAnchorElement
 import org.w3c.dom.HTMLInputElement
 import org.w3c.files.FileReader
+import iconBars
 import sortable.Sortable
 import sortable.SortableEvent
 import sortable.sortableOptions
@@ -115,8 +116,19 @@ fun RenderContext.codesScreen(
                         val displayName = code.name.ifBlank { code.text }
                         val truncated = if (displayName.length > 60) displayName.take(60) + "..." else displayName
                         li(
-                            "card bg-base-200 rounded-2xl p-4 cursor-pointer w-full flex flex-col items-center gap-3 text-center"
+                            "card bg-base-200 rounded-2xl p-4 cursor-pointer w-full flex flex-col items-center gap-3 text-center relative"
                         ) {
+                            button(
+                                "btn btn-ghost btn-xs btn-circle absolute right-3 top-3 drag-handle cursor-grab touch-none"
+                            ) {
+                                attr("type", "button")
+                                attr("aria-label", getTranslationString(DefaultLangStrings.DragToReorder))
+                                iconBars()
+                                domNode.addEventListener("click", { event ->
+                                    event.stopPropagation()
+                                    event.preventDefault()
+                                })
+                            }
                             qrCodeImage(
                                 text = code.text,
                                 size = 160,
@@ -132,6 +144,10 @@ fun RenderContext.codesScreen(
                 }
                 Sortable(ulElement.domNode as HTMLElement, sortableOptions {
                     animation = 150
+                    handle = ".drag-handle"
+                    delay = 150
+                    delayOnTouchOnly = true
+                    touchStartThreshold = 8
                     onEnd = { evt ->
                         val from = evt.oldIndex
                         val to = evt.newIndex

--- a/src/jsMain/kotlin/sortable/Sortable.kt
+++ b/src/jsMain/kotlin/sortable/Sortable.kt
@@ -18,4 +18,8 @@ external interface SortableEvent {
 external interface SortableOptions {
     var animation: Int?
     var onEnd: ((SortableEvent) -> Unit)?
+    var handle: String?
+    var delay: Int?
+    var delayOnTouchOnly: Boolean?
+    var touchStartThreshold: Int?
 }


### PR DESCRIPTION
## Summary
- add a dedicated drag handle to saved code cards to avoid accidental drags while scrolling on touch devices
- gate sortable.js reordering behind the handle and touch delay to balance responsiveness and stability
- provide "Drag to reorder" translations across supported locales

## Testing
- `./gradlew -Pkotlin.js.yarn.ignore.yarn.lock=true -Pkotlin.js.yarn.lock.store=false jsBrowserDevelopmentWebpack --console=plain`
- `./gradlew -Pkotlin.js.yarn.ignore.yarn.lock=true -Pkotlin.js.yarn.lock.store=false jsBrowserProductionWebpack --console=plain`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d2ca9d3788832e808ae1455eeffb6a