### PR TITLE
Add Barcode Detection API support with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Hoover
 
-Code Hoover is a small web application that lets you scan QR codes and barcodes directly in the browser. It is written in Kotlin/JS using the fritz2 framework and relies on the excellent [@zxing/browser](https://github.com/zxing-js/browser) package for the heavy lifting when decoding codes.
+Code Hoover is a small web application that lets you scan QR codes and barcodes directly in the browser. It is written in Kotlin/JS using the fritz2 framework, prefers the native [Barcode Detection API](https://developer.mozilla.org/en-US/docs/Web/API/Barcode_Detection_API) when available, and falls back to the excellent [@zxing/browser](https://github.com/zxing-js/browser) package for decoding.
 
 [![Screenshot](screenshot.webp)](URL)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2134,6 +2134,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2376,6 +2377,7 @@
       "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/public/lang/de-DE.ftl
+++ b/public/lang/de-DE.ftl
@@ -4,6 +4,7 @@ default-welcome-text=
 default-scan=Scannen
 default-stop=Stopp
 default-clear=Leeren
+default-scanner-library=Scanner: { $value }
 default-copy=Kopieren
 default-dark-mode=Dunkelmodus
 default-codes=Codes

--- a/public/lang/en-US.ftl
+++ b/public/lang/en-US.ftl
@@ -4,6 +4,7 @@ default-welcome-text=
 default-scan=Scan
 default-stop=Stop
 default-clear=Clear
+default-scanner-library=Scanner: { $value }
 default-copy=Copy
 default-dark-mode=Dark Mode
 default-codes=Codes

--- a/public/lang/fr-FR.ftl
+++ b/public/lang/fr-FR.ftl
@@ -4,6 +4,7 @@ default-welcome-text=
 default-scan=Scanner
 default-stop=Arrêter
 default-clear=Effacer
+default-scanner-library=Scanner : { $value }
 default-copy=Copier
 default-dark-mode=Mode sombre
 default-codes=Codes

--- a/public/lang/ja-JP.ftl
+++ b/public/lang/ja-JP.ftl
@@ -4,6 +4,7 @@ default-welcome-text=
 default-scan=スキャン
 default-stop=停止
 default-clear=クリア
+default-scanner-library=スキャナー: { $value }
 default-copy=コピー
 default-dark-mode=ダークモード
 default-codes=コード

--- a/public/lang/nl-NL.ftl
+++ b/public/lang/nl-NL.ftl
@@ -4,6 +4,7 @@ default-welcome-text=
 default-scan=Scannen
 default-stop=Stop
 default-clear=Wissen
+default-scanner-library=Scanner: { $value }
 default-copy=Kopiëren
 default-dark-mode=Donkere modus
 default-codes=Codes

--- a/src/jsMain/kotlin/App.kt
+++ b/src/jsMain/kotlin/App.kt
@@ -50,6 +50,8 @@ fun barcodeFormatName(ordinal: Int): String =
     if (ordinal in barcodeFormatNames.indices) barcodeFormatNames[ordinal]
     else getTranslationString(DefaultLangStrings.Unknown)
 
+fun barcodeFormatOrdinal(name: String): Int = barcodeFormatNames.indexOf(name)
+
 private const val darkMode = "qr-dark"
 
 private const val lightMode = "qr-light"
@@ -352,6 +354,7 @@ enum class DefaultLangStrings : Translatable {
     Scan,
     Stop,
     Clear,
+    ScannerLibrary,
     Copy,
     DarkMode,
     Codes,

--- a/src/jsMain/kotlin/BarcodeDetectorApi.kt
+++ b/src/jsMain/kotlin/BarcodeDetectorApi.kt
@@ -1,0 +1,18 @@
+import kotlin.js.Promise
+
+external class BarcodeDetector(options: BarcodeDetectorOptions = definedExternally) {
+    fun detect(source: dynamic): Promise<Array<DetectedBarcode>>
+
+    companion object {
+        fun getSupportedFormats(): Promise<Array<String>>
+    }
+}
+
+external interface BarcodeDetectorOptions {
+    var formats: Array<String>?
+}
+
+external interface DetectedBarcode {
+    val rawValue: String
+    val format: String
+}

--- a/src/jsMain/kotlin/ScanScreen.kt
+++ b/src/jsMain/kotlin/ScanScreen.kt
@@ -1,7 +1,6 @@
-import DefaultLangStrings
-import barcodeFormatName
-import barcodeFormatOrdinal
-import dev.fritz2.core.*
+import dev.fritz2.core.RenderContext
+import dev.fritz2.core.Store
+import dev.fritz2.core.storeOf
 import kotlinx.browser.document
 import kotlinx.browser.window
 import kotlinx.coroutines.Job
@@ -9,12 +8,11 @@ import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.await
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import localization.getTranslationString
 import localization.translate
 import org.w3c.dom.HTMLVideoElement
-import org.w3c.dom.MediaStream
+import org.w3c.dom.mediacapture.MediaStream
 import org.w3c.dom.mediacapture.MediaStreamTrack
 import qr.QrData
 import qr.SavedQrCode

--- a/src/jsMain/kotlin/ScanScreen.kt
+++ b/src/jsMain/kotlin/ScanScreen.kt
@@ -1,15 +1,26 @@
+import DefaultLangStrings
+import barcodeFormatName
+import barcodeFormatOrdinal
 import dev.fritz2.core.*
+import kotlinx.browser.document
 import kotlinx.browser.window
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.await
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import localization.getTranslationString
+import localization.translate
+import org.w3c.dom.HTMLVideoElement
+import org.w3c.dom.MediaStream
+import org.w3c.dom.mediacapture.MediaStreamTrack
 import qr.QrData
 import qr.SavedQrCode
 import qr.asText
 import qr.defaultDisplayName
 import qr.parseVCard
-import localization.getTranslationString
-import localization.translate
-import DefaultLangStrings
 
 fun RenderContext.scanScreen(
     scanningStore: Store<Boolean>,
@@ -18,7 +29,94 @@ fun RenderContext.scanScreen(
     savedCodesStore: Store<List<SavedQrCode>>,
     json: Json
 ) {
+    val scope = MainScope()
     var controls: IScannerControls? = null
+    var mediaStream: MediaStream? = null
+    var detectionJob: Job? = null
+    val barcodeDetectorAvailable = isBarcodeDetectorAvailable()
+    val scannerLabelStore = storeOf(
+        if (barcodeDetectorAvailable) "Barcode Detector API" else "@zxing/browser",
+    )
+
+    fun stopBarcodeDetector() {
+        mediaStream?.getTracks()?.forEach(MediaStreamTrack::stop)
+        mediaStream = null
+        (document.getElementById("video") as? HTMLVideoElement)?.apply {
+            pause()
+            srcObject = null
+        }
+    }
+
+    fun stopScanning() {
+        controls?.stop()
+        controls = null
+        detectionJob?.cancel()
+        detectionJob = null
+        stopBarcodeDetector()
+        scanningStore.update(false)
+    }
+
+    suspend fun startBarcodeDetector(videoElement: HTMLVideoElement): Boolean {
+        return try {
+            val detector = BarcodeDetector()
+            val stream = window.navigator.mediaDevices.getUserMedia(
+                js("{ video: { facingMode: 'environment' } }"),
+            ).await()
+            mediaStream = stream
+            videoElement.srcObject = stream
+            videoElement.play().await()
+            scannerLabelStore.update("Barcode Detector API")
+            detectionJob = scope.launch {
+                while (scanningStore.current) {
+                    try {
+                        val results = detector.detect(videoElement).await()
+                        if (results.isNotEmpty()) {
+                            results.forEach { barcode ->
+                                val text = barcode.rawValue
+                                val formatOrdinal =
+                                    barcodeFormatOrdinal(
+                                        barcode.format.replace("-", "_").uppercase(),
+                                    )
+                                val existing = scansStore.current
+                                if (existing.none { it.text == text }) {
+                                    scansStore.update(
+                                        listOf(ScanResult(text, formatOrdinal)) + existing,
+                                    )
+                                }
+                            }
+                        }
+                        delay(300)
+                    } catch (_: Throwable) {
+                        delay(300)
+                    }
+                }
+            }
+            true
+        } catch (_: Throwable) {
+            stopBarcodeDetector()
+            false
+        }
+    }
+
+    fun startZxingScanner() {
+        scannerLabelStore.update("@zxing/browser")
+        codeReader.decodeFromVideoDevice(
+            null,
+            "video",
+        ) { result, _, c ->
+            controls = c
+            if (result != null) {
+                val text = result.text
+                val format = result.format
+                val existing = scansStore.current
+                if (existing.none { it.text == text }) {
+                    scansStore.update(
+                        listOf(ScanResult(text, format)) + existing,
+                    )
+                }
+            }
+        }
+    }
     scanningStore.data.render { scanning ->
         section("flex flex-col items-center gap-4 w-full") {
             div("join flex-wrap w-full justify-center md:justify-start") {
@@ -27,9 +125,7 @@ fun RenderContext.scanScreen(
                         iconStop()
                         translate(DefaultLangStrings.Stop)
                         clicks handledBy {
-                            controls?.stop()
-                            controls = null
-                            scanningStore.update(false)
+                            stopScanning()
                         }
                     }
                 } else {
@@ -37,23 +133,26 @@ fun RenderContext.scanScreen(
                         iconCamera()
                         translate(DefaultLangStrings.Scan)
                         clicks handledBy {
-                            codeReader.decodeFromVideoDevice(
-                                null,
-                                "video",
-                            ) { result, _, c ->
-                                controls = c
-                                if (result != null) {
-                                    val text = result.text
-                                    val format = result.format
-                                    val existing = scansStore.current
-                                    if (existing.none { it.text == text }) {
-                                        scansStore.update(
-                                            listOf(ScanResult(text, format)) + existing,
-                                        )
+                            scanningStore.update(true)
+                            scope.launch {
+                                var videoElement: HTMLVideoElement? = null
+                                for (attempt in 0 until 5) {
+                                    videoElement =
+                                        document.getElementById("video") as? HTMLVideoElement
+                                    if (videoElement != null) break
+                                    delay(50)
+                                }
+                                val targetVideo = videoElement
+                                if (targetVideo == null) {
+                                    stopScanning()
+                                } else {
+                                    val startedWithNative =
+                                        barcodeDetectorAvailable && startBarcodeDetector(targetVideo)
+                                    if (!startedWithNative) {
+                                        startZxingScanner()
                                     }
                                 }
                             }
-                            scanningStore.update(true)
                         }
                     }
                 }
@@ -63,6 +162,11 @@ fun RenderContext.scanScreen(
                     clicks handledBy {
                         scansStore.update(emptyList())
                     }
+                }
+            }
+            scannerLabelStore.data.render { label ->
+                p("text-sm opacity-70") {
+                    translate(DefaultLangStrings.ScannerLibrary, mapOf("value" to label))
                 }
             }
             if (!scanning) {
@@ -145,3 +249,6 @@ fun RenderContext.scanScreen(
         }
     }
 }
+
+private fun isBarcodeDetectorAvailable(): Boolean =
+    js("typeof BarcodeDetector !== 'undefined'") as Boolean


### PR DESCRIPTION
## Summary
- add support for the native Barcode Detection API with a graceful fallback to @zxing/browser
- display which scanner engine is active in the scan UI and localize the label
- document the updated detection approach in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aa6f17de4832e805676465f3a098f)